### PR TITLE
Better support for 256 color terminals (16 colors bleh)

### DIFF
--- a/colors/gotham.vim
+++ b/colors/gotham.vim
@@ -68,24 +68,24 @@ endfunction
 let s:colors = {}
 
 " Base colors.
-let s:colors.base0 = { 'gui': '#0c1014', 'cterm': 0 }
-let s:colors.base1 = { 'gui': '#11151c', 'cterm': 8 }
-let s:colors.base2 = { 'gui': '#091f2e', 'cterm': 10 }
-let s:colors.base3 = { 'gui': '#0a3749', 'cterm': 12 }
-let s:colors.base4 = { 'gui': '#245361', 'cterm': 11 }
-let s:colors.base5 = { 'gui': '#599cab', 'cterm': 14 }
-let s:colors.base6 = { 'gui': '#99d1ce', 'cterm': 7 }
-let s:colors.base7 = { 'gui': '#d3ebe9', 'cterm': 15 }
+let s:colors.base0 = { 'gui': '#0c1014', 'cterm': 232 }
+let s:colors.base1 = { 'gui': '#11151c', 'cterm': 233 }
+let s:colors.base2 = { 'gui': '#091f2e', 'cterm': 17  }
+let s:colors.base3 = { 'gui': '#0a3749', 'cterm': 18  }
+let s:colors.base4 = { 'gui': '#245361', 'cterm': 24  }
+let s:colors.base5 = { 'gui': '#599cab', 'cterm': 81  }
+let s:colors.base6 = { 'gui': '#99d1ce', 'cterm': 122 }
+let s:colors.base7 = { 'gui': '#d3ebe9', 'cterm': 194 }
 
 " Other colors.
-let s:colors.red     = { 'gui': '#c23127', 'cterm': 1  }
-let s:colors.orange  = { 'gui': '#d26937', 'cterm': 9  }
-let s:colors.yellow  = { 'gui': '#edb443', 'cterm': 3  }
-let s:colors.magenta = { 'gui': '#888ca6', 'cterm': 13 }
-let s:colors.violet  = { 'gui': '#4e5166', 'cterm': 5  }
-let s:colors.blue    = { 'gui': '#195466', 'cterm': 4  }
-let s:colors.cyan    = { 'gui': '#33859E', 'cterm': 6  }
-let s:colors.green   = { 'gui': '#2aa889', 'cterm': 2  }
+let s:colors.red     = { 'gui': '#c23127', 'cterm': 124 }
+let s:colors.orange  = { 'gui': '#d26937', 'cterm': 166 }
+let s:colors.yellow  = { 'gui': '#edb443', 'cterm': 214 }
+let s:colors.magenta = { 'gui': '#888ca6', 'cterm': 67  }
+let s:colors.violet  = { 'gui': '#4e5166', 'cterm': 60  }
+let s:colors.blue    = { 'gui': '#195466', 'cterm': 24  }
+let s:colors.cyan    = { 'gui': '#33859E', 'cterm': 44  }
+let s:colors.green   = { 'gui': '#2aa889', 'cterm': 78  }
 
 
 " Native highlighting ==========================================================


### PR DESCRIPTION
The non-gui color support of this is pretty bleh. I modifed the 16 color terminal (who uses that anymore) to be 256 color compatible. It's MUCH more usable at a terminal now. I tried to keep the colors as close to the GUI as I could get them within the limited color space.
