### PR TITLE
"Thinner" VertSplit and different LineNr and SignColumn

### DIFF
--- a/colors/gotham.vim
+++ b/colors/gotham.vim
@@ -103,7 +103,7 @@ call s:Col('CursorLine', '', 'base1')
 " Sign column, line numbers.
 call s:Col('LineNr', 'base4', s:linenr_background)
 call s:Col('CursorLineNr', 'base5', s:linenr_background)
-call s:Col('SignColumn', '', s:linenr_background)
+call s:Col('SignColumn', '', s:background)
 call s:Col('ColorColumn', '', s:linenr_background)
 
 " Visual selection.

--- a/colors/gotham256.vim
+++ b/colors/gotham256.vim
@@ -103,7 +103,7 @@ call s:Col('CursorLine', '', 'base1')
 " Sign column, line numbers.
 call s:Col('LineNr', 'base4', s:linenr_background)
 call s:Col('CursorLineNr', 'base5', s:linenr_background)
-call s:Col('SignColumn', '', s:linenr_background)
+call s:Col('SignColumn', '', s:background)
 call s:Col('ColorColumn', '', s:linenr_background)
 
 " Visual selection.


### PR DESCRIPTION
Hi @whatyouhide 
Here is my pull request about issue #9.

In order to see the changes, be sure to set something like this:

``` viml
set fillchars+=vert:\│
```
