### PR TITLE
Make CursorColumn the same as CursorLine

### DIFF
--- a/colors/gotham.vim
+++ b/colors/gotham.vim
@@ -99,6 +99,7 @@ call s:Col('Normal', 'base6', s:background)
 " Line, cursor and so on.
 call s:Col('Cursor', 'base1', 'base6')
 call s:Col('CursorLine', '', 'base1')
+call s:Col('CursorColumn', '', 'base1')
 
 " Sign column, line numbers.
 call s:Col('LineNr', 'base4', s:linenr_background)

--- a/colors/gotham256.vim
+++ b/colors/gotham256.vim
@@ -99,6 +99,7 @@ call s:Col('Normal', 'base6', s:background)
 " Line, cursor and so on.
 call s:Col('Cursor', 'base1', 'base6')
 call s:Col('CursorLine', '', 'base1')
+call s:Col('CursorColumn', '', 'base1')
 
 " Sign column, line numbers.
 call s:Col('LineNr', 'base4', s:linenr_background)


### PR DESCRIPTION
- These two highlight groups are the same by default, should keep
  them that way.
- The motivation behind this is to make the scheme more compatible
  with the vim-paren-crosshairs plugin
