### PR TITLE
Fix lightline setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Gotham supports [lightline.vim][lightline.vim] too. To enable the colorscheme,
 add one of the following lines to your `.vimrc`:
 
 ``` viml
-let g:lightline.colorscheme = 'gotham'
-let g:lightline.colorscheme = 'gotham256'
+let g:lightline = { 'colorscheme': 'gotham' }
+let g:lightline = { 'colorscheme': 'gotham256' }
 ```
 
 


### PR DESCRIPTION
I'm not an expert in VimL, but `let g:lightline.colorscheme = 'gotham256'` didn't work for me. Maybe it's because of neovim.

```
Error detected while processing /Users/igas/.nvimrc:
line   30:
E121: Undefined variable: g:lightline
Press ENTER or type command to continue
```