### PR TITLE
refactor: Unite support without touching internals

### DIFF
--- a/colors/gotham.vim
+++ b/colors/gotham.vim
@@ -228,7 +228,8 @@ call s:Col('CtrlPPrtText', 'cyan')              " text in the prompt
 call s:Col('CtrlPPtrCursor', 'base7')           " cursor in the prompt
 
 " unite.vim
-call s:Col('uniteSource__GrepPattern', 'base7', 'green')
+call s:Col('UniteGrep', 'base7', 'green')
+let g:unite_source_grep_search_word_highlight = 'UniteGrep'
 
 
 " Cleanup =====================================================================

--- a/colors/gotham256.vim
+++ b/colors/gotham256.vim
@@ -227,6 +227,9 @@ call s:Col('CtrlPPrtBase', 'base4')             " '>>>' prompt
 call s:Col('CtrlPPrtText', 'cyan')              " text in the prompt
 call s:Col('CtrlPPtrCursor', 'base7')           " cursor in the prompt
 
+" unite.vim
+call s:Col('UniteGrep', 'base7', 'green')
+let g:unite_source_grep_search_word_highlight = 'UniteGrep'
 
 
 " Cleanup =====================================================================


### PR DESCRIPTION
g:unite_source_grep_search_word_highlight takes a highlight group as an
argument, so create our own highlight group and assign it, rather than
override the internal highlight group name directly.