### PR TITLE
Add syntax support for Python (klen/python-mode)

### DIFF
--- a/colors/gotham.vim
+++ b/colors/gotham.vim
@@ -211,6 +211,9 @@ call s:Col('htmlArg', 'blue')
 call s:Col('htmlItalic', 'magenta')
 call s:Col('htmlBold', 'cyan', '')
 
+" Python                                                                                                                   
+call s:Col('pythonStatement', 'blue')
+
 
 " Plugin =======================================================================
 

--- a/colors/gotham256.vim
+++ b/colors/gotham256.vim
@@ -211,6 +211,9 @@ call s:Col('htmlArg', 'blue')
 call s:Col('htmlItalic', 'magenta')
 call s:Col('htmlBold', 'cyan', '')
 
+" Python                                                                                                                   
+call s:Col('pythonStatement', 'blue')
+
 
 " Plugin =======================================================================
 


### PR DESCRIPTION
Hi,

I propose this small enhancement for python syntax support. By default the statement like class/def .. are coloured in cyan which confuses with user-defined name color (.ie in the screenshot def run(self)). So with this fix, we have the same behaviour as for Ruby (blue colour).
Here is a screenshot after the commit:

![screenshot 2015-09-30 09 27 35](https://cloud.githubusercontent.com/assets/9952320/10187023/8bb526fe-6755-11e5-87b2-16ca2bf73b5a.png)

Thanks in advance for your comments!

Youssef