### PR TITLE
Add support for more diff hl-groups: (Added/Changed/Removed/Subname)

### DIFF
--- a/colors/gotham.vim
+++ b/colors/gotham.vim
@@ -195,6 +195,10 @@ call s:Col('DiffAdd', 'base7', 'green')
 call s:Col('DiffChange', 'base7', 'blue')
 call s:Col('DiffDelete', 'base7', 'red')
 call s:Col('DiffText', 'base7', 'cyan')
+call s:Col('DiffAdded', 'green')
+call s:Col('DiffChanged', 'blue')
+call s:Col('DiffRemoved', 'red')
+call s:Col('DiffSubname', 'base4')
 
 " Directories (e.g. netrw).
 call s:Col('Directory', 'cyan')

--- a/colors/gotham256.vim
+++ b/colors/gotham256.vim
@@ -195,6 +195,10 @@ call s:Col('DiffAdd', 'base7', 'green')
 call s:Col('DiffChange', 'base7', 'blue')
 call s:Col('DiffDelete', 'base7', 'red')
 call s:Col('DiffText', 'base7', 'cyan')
+call s:Col('DiffAdded', 'green')
+call s:Col('DiffChanged', 'blue')
+call s:Col('DiffRemoved', 'red')
+call s:Col('DiffSubname', 'base4')
 
 " Directories (e.g. netrw).
 call s:Col('Directory', 'cyan')


### PR DESCRIPTION
Obviously this is a somewhat subjective change but I noticed that Gotham wasn't defining highlight groups for diff files and I found the defaults difficult to read.

This PR adds highlighting for the DiffAdded, DiffChanged, DiffRemoved, and DiffSubname highlight groups instead of relying on the default links created by `$VIMRUNTIME/syntax/diff.vim`

I don't usually read diff files, but I do look at a lot of raw diff output generated by Fugitive.  My main use case being commands like `Git! show <some commit>` or `Git! diff <commits>`.

Not sure if you left the default highlight group links on purpose or not but hopefully you'll like these changes.