### PR TITLE
Change the color of airline

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ version and the 256 colors version:
     :AirlineTheme gotham
     :AirlineTheme gotham256
 
+Gotham by default emphasises the usage of insert mode by using a distinctive bright yellow color in
+the airline mode segment. To change the color used for insert mode to a darker less emphasised color
+add the following to your vimrc:
+
+```viml
+let g:gotham_airline_emphasised_insert = 0
+```
+
 #### Lightline
 
 Gotham supports [lightline.vim][lightline.vim] too. To enable the colorscheme,
@@ -71,13 +79,6 @@ add one of the following lines to your `.vimrc`:
 ``` viml
 let g:lightline = { 'colorscheme': 'gotham' }
 let g:lightline = { 'colorscheme': 'gotham256' }
-```
-
-If you want to increase the contrast of the modeline when in insert mode, then set the following
-config variable in your vimrc:
-
-```viml
-let g:gotham_airline_contrast_mode = 1
 ```
 
 ### <a name=other></a>Other

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ let g:lightline = { 'colorscheme': 'gotham' }
 let g:lightline = { 'colorscheme': 'gotham256' }
 ```
 
+If you want to increase the contrast of the modeline when in insert mode, then set the following
+config variable in your vimrc:
+
+```viml
+let g:gotham_airline_contrast_mode = 1
+```
 
 ### <a name=other></a>Other
 

--- a/autoload/airline/themes/gotham.vim
+++ b/autoload/airline/themes/gotham.vim
@@ -42,7 +42,7 @@ endfunction
 " Normal mode =================================================================
 
 " Colors.
-let s:N1 = s:Array('base3', 'blue')
+let s:N1 = s:Array('base2', 'blue')
 let s:N2 = s:Array('base5', 'base2')
 let s:N3 = s:Array('base4', 'base1')
 
@@ -58,9 +58,14 @@ let g:airline#themes#gotham#palette.normal_modified = {
 " Insert mode ==================================================================
 
 " Colors.
-let s:I1 = s:Array('base4', 'green')
+let s:I1 = s:Array('base2', 'green')
 let s:I2 = s:Array('base6', 'base3')
 let s:I3 = s:Array('base4', 'base1')
+
+" Override for when increased contrast is enabled
+if get(g:, 'gotham_airline_contrast_mode', 1)
+  let s:I1 = s:Array('base2', 'yellow')
+endif
 
 let g:airline#themes#gotham#palette.insert =
       \ airline#themes#generate_color_map(s:I1, s:I2, s:I3)
@@ -73,6 +78,7 @@ let g:airline#themes#gotham#palette.insert_modified = {
 " Overrides for when the paste is toggled in insert mode.
 let g:airline#themes#gotham#palette.insert_paste = {
       \ 'airline_a': [s:I1[0], s:c.orange.gui, s:I1[2], s:c.orange.cterm, ''] ,
+      \ 'airline_z': [s:I1[0], s:c.orange.gui, s:I1[2], s:c.orange.cterm, ''] ,
       \ }
 
 
@@ -80,8 +86,8 @@ let g:airline#themes#gotham#palette.insert_paste = {
 " Replace mode ================================================================
 
 " Colors.
-let s:R1 = s:Array('base3', 'orange')
-let s:R2 = s:Array('base5', 'base2')
+let s:R1 = s:Array('base2', 'orange')
+let s:R2 = s:Array('base6', 'base3')
 let s:R3 = s:Array('base4', 'base1')
 
 let g:airline#themes#gotham#palette.replace =
@@ -97,7 +103,7 @@ let g:airline#themes#gotham#palette.replace_modified = {
 " Visual mode =================================================================
 
 " Colors.
-let s:V1 = s:Array('base3', 'magenta')
+let s:V1 = s:Array('base2', 'magenta')
 let s:V2 = s:Array('base6', 'base3')
 let s:V3 = s:N3
 

--- a/autoload/airline/themes/gotham.vim
+++ b/autoload/airline/themes/gotham.vim
@@ -58,7 +58,7 @@ let g:airline#themes#gotham#palette.normal_modified = {
 " Insert mode ==================================================================
 
 " Colors.
-let s:I1 = s:Array('base7', 'yellow')
+let s:I1 = s:Array('base7', 'magenta')
 let s:I2 = s:Array('base6', 'base3')
 let s:I3 = s:Array('base4', 'base1')
 

--- a/autoload/airline/themes/gotham.vim
+++ b/autoload/airline/themes/gotham.vim
@@ -42,7 +42,7 @@ endfunction
 " Normal mode =================================================================
 
 " Colors.
-let s:N1 = s:Array('base7', 'base4')
+let s:N1 = s:Array('base3', 'blue')
 let s:N2 = s:Array('base5', 'base2')
 let s:N3 = s:Array('base4', 'base1')
 
@@ -58,7 +58,7 @@ let g:airline#themes#gotham#palette.normal_modified = {
 " Insert mode ==================================================================
 
 " Colors.
-let s:I1 = s:Array('base7', 'magenta')
+let s:I1 = s:Array('base4', 'green')
 let s:I2 = s:Array('base6', 'base3')
 let s:I3 = s:Array('base4', 'base1')
 
@@ -79,21 +79,25 @@ let g:airline#themes#gotham#palette.insert_paste = {
 
 " Replace mode ================================================================
 
-" Let's start with the same palette as insert mode...
+" Colors.
+let s:R1 = s:Array('base3', 'orange')
+let s:R2 = s:Array('base5', 'base2')
+let s:R3 = s:Array('base4', 'base1')
+
 let g:airline#themes#gotham#palette.replace =
-      \ copy(g:airline#themes#gotham#palette.insert)
-let g:airline#themes#gotham#palette.replace_modified =
-      \ g:airline#themes#gotham#palette.insert_modified
-" ...and tweak it slightly.
-let g:airline#themes#gotham#palette.replace.airline_a =
-      \ [s:I2[0], s:c.red.gui, s:I2[2], 124, '']
+      \ airline#themes#generate_color_map(s:R1, s:R2, s:R3)
+
+" Overrides for when the buffer is modified in normal mode.
+let g:airline#themes#gotham#palette.replace_modified = {
+      \ 'airline_c': s:Array('magenta', 'base1', '')
+      \ }
 
 
 
 " Visual mode =================================================================
 
 " Colors.
-let s:V1 = s:Array('base7', 'green')
+let s:V1 = s:Array('base3', 'magenta')
 let s:V2 = s:Array('base6', 'base3')
 let s:V3 = s:N3
 

--- a/autoload/airline/themes/gotham.vim
+++ b/autoload/airline/themes/gotham.vim
@@ -63,7 +63,7 @@ let s:I2 = s:Array('base6', 'base3')
 let s:I3 = s:Array('base4', 'base1')
 
 " Override for when increased contrast is enabled
-if get(g:, 'gotham_airline_contrast_mode', 1)
+if get(g:, 'gotham_airline_emphasised_insert', 1)
   let s:I1 = s:Array('base2', 'yellow')
 endif
 

--- a/autoload/airline/themes/gotham256.vim
+++ b/autoload/airline/themes/gotham256.vim
@@ -42,7 +42,7 @@ endfunction
 " Normal mode =================================================================
 
 " Colors.
-let s:N1 = s:Array('base7', 'base4')
+let s:N1 = s:Array('base3', 'blue')
 let s:N2 = s:Array('base5', 'base2')
 let s:N3 = s:Array('base4', 'base1')
 
@@ -58,7 +58,7 @@ let g:airline#themes#gotham256#palette.normal_modified = {
 " Insert mode ==================================================================
 
 " Colors.
-let s:I1 = s:Array('base7', 'magenta')
+let s:I1 = s:Array('base4', 'green')
 let s:I2 = s:Array('base6', 'base3')
 let s:I3 = s:Array('base4', 'base1')
 
@@ -79,21 +79,25 @@ let g:airline#themes#gotham256#palette.insert_paste = {
 
 " Replace mode ================================================================
 
-" Let's start with the same palette as insert mode...
-let g:airline#themes#gotham256#palette.replace =
-      \ copy(g:airline#themes#gotham256#palette.insert)
-let g:airline#themes#gotham256#palette.replace_modified =
-      \ g:airline#themes#gotham256#palette.insert_modified
-" ...and tweak it slightly.
-let g:airline#themes#gotham256#palette.replace.airline_a =
-      \ [s:I2[0], s:c.red.gui, s:I2[2], 124, '']
+" Colors.
+let s:R1 = s:Array('base3', 'orange')
+let s:R2 = s:Array('base5', 'base2')
+let s:R3 = s:Array('base4', 'base1')
+
+let g:airline#themes#gotham#palette.replace =
+      \ airline#themes#generate_color_map(s:R1, s:R2, s:R3)
+
+" Overrides for when the buffer is modified in normal mode.
+let g:airline#themes#gotham#palette.replace_modified = {
+      \ 'airline_c': s:Array('magenta', 'base1', '')
+      \ }
 
 
 
 " Visual mode =================================================================
 
 " Colors.
-let s:V1 = s:Array('base7', 'green')
+let s:V1 = s:Array('base3', 'magenta')
 let s:V2 = s:Array('base6', 'base3')
 let s:V3 = s:N3
 

--- a/autoload/airline/themes/gotham256.vim
+++ b/autoload/airline/themes/gotham256.vim
@@ -58,7 +58,7 @@ let g:airline#themes#gotham256#palette.normal_modified = {
 " Insert mode ==================================================================
 
 " Colors.
-let s:I1 = s:Array('base7', 'yellow')
+let s:I1 = s:Array('base7', 'magenta')
 let s:I2 = s:Array('base6', 'base3')
 let s:I3 = s:Array('base4', 'base1')
 

--- a/autoload/airline/themes/gotham256.vim
+++ b/autoload/airline/themes/gotham256.vim
@@ -63,7 +63,7 @@ let s:I2 = s:Array('base6', 'base3')
 let s:I3 = s:Array('base4', 'base1')
 
 " Override for when increased contrast is enabled
-if get(g:, 'gotham_airline_contrast_mode', 1)
+if get(g:, 'gotham_airline_emphasised_insert', 1)
   let s:I1 = s:Array('base2', 'yellow')
 endif
 

--- a/autoload/airline/themes/gotham256.vim
+++ b/autoload/airline/themes/gotham256.vim
@@ -42,7 +42,7 @@ endfunction
 " Normal mode =================================================================
 
 " Colors.
-let s:N1 = s:Array('base3', 'blue')
+let s:N1 = s:Array('base2', 'blue')
 let s:N2 = s:Array('base5', 'base2')
 let s:N3 = s:Array('base4', 'base1')
 
@@ -58,9 +58,14 @@ let g:airline#themes#gotham256#palette.normal_modified = {
 " Insert mode ==================================================================
 
 " Colors.
-let s:I1 = s:Array('base4', 'green')
+let s:I1 = s:Array('base2', 'green')
 let s:I2 = s:Array('base6', 'base3')
 let s:I3 = s:Array('base4', 'base1')
+
+" Override for when increased contrast is enabled
+if get(g:, 'gotham_airline_contrast_mode', 1)
+  let s:I1 = s:Array('base2', 'yellow')
+endif
 
 let g:airline#themes#gotham256#palette.insert =
       \ airline#themes#generate_color_map(s:I1, s:I2, s:I3)
@@ -73,6 +78,7 @@ let g:airline#themes#gotham256#palette.insert_modified = {
 " Overrides for when the paste is toggled in insert mode.
 let g:airline#themes#gotham256#palette.insert_paste = {
       \ 'airline_a': [s:I1[0], s:c.orange.gui, s:I1[2], s:c.orange.cterm, ''] ,
+      \ 'airline_z': [s:I1[0], s:c.orange.gui, s:I1[2], s:c.orange.cterm, ''] ,
       \ }
 
 
@@ -80,8 +86,8 @@ let g:airline#themes#gotham256#palette.insert_paste = {
 " Replace mode ================================================================
 
 " Colors.
-let s:R1 = s:Array('base3', 'orange')
-let s:R2 = s:Array('base5', 'base2')
+let s:R1 = s:Array('base2', 'orange')
+let s:R2 = s:Array('base6', 'base3')
 let s:R3 = s:Array('base4', 'base1')
 
 let g:airline#themes#gotham#palette.replace =
@@ -97,7 +103,7 @@ let g:airline#themes#gotham#palette.replace_modified = {
 " Visual mode =================================================================
 
 " Colors.
-let s:V1 = s:Array('base3', 'magenta')
+let s:V1 = s:Array('base2', 'magenta')
 let s:V2 = s:Array('base6', 'base3')
 let s:V3 = s:N3
 


### PR DESCRIPTION
This fixes #23 

The default airline color used for insert mode doesn't really fit the overall look of gotham. Also the white on yellow makes it very hard to read that the active mode is insert.

This changes the color used for insert mode to magenta. See the screenshots below for (before / after)

![screen shot 2016-02-26 at 21 22 41](https://cloud.githubusercontent.com/assets/1220084/13364488/591d23d2-dccf-11e5-8789-69a90ef7113c.png)

![screen shot 2016-02-26 at 21 24 12](https://cloud.githubusercontent.com/assets/1220084/13364487/591a3bae-dccf-11e5-9670-a938d7722554.png)
