### PR TITLE
Override neovim :terminal colors

### DIFF
--- a/colors/gotham.vim
+++ b/colors/gotham.vim
@@ -87,6 +87,24 @@ let s:colors.blue    = { 'gui': '#195466', 'cterm': 4  }
 let s:colors.cyan    = { 'gui': '#33859E', 'cterm': 6  }
 let s:colors.green   = { 'gui': '#2aa889', 'cterm': 2  }
 
+" Neovim :terminal colors.
+let g:terminal_color_0  = get(s:colors.base0, 'gui')
+let g:terminal_color_8  = get(s:colors.base1, 'gui')
+let g:terminal_color_1  = get(s:colors.red, 'gui')
+let g:terminal_color_9  = get(s:colors.orange, 'gui')
+let g:terminal_color_2  = get(s:colors.green, 'gui')
+let g:terminal_color_10 = get(s:colors.base2, 'gui')
+let g:terminal_color_3  = get(s:colors.yellow, 'gui')
+let g:terminal_color_11 = get(s:colors.base4, 'gui')
+let g:terminal_color_4  = get(s:colors.blue, 'gui')
+let g:terminal_color_12 = get(s:colors.base3, 'gui')
+let g:terminal_color_5  = get(s:colors.violet, 'gui')
+let g:terminal_color_13 = get(s:colors.magenta, 'gui')
+let g:terminal_color_6  = get(s:colors.cyan, 'gui')
+let g:terminal_color_14 = get(s:colors.base5, 'gui')
+let g:terminal_color_7  = get(s:colors.base6, 'gui')
+let g:terminal_color_15 = get(s:colors.base7, 'gui')
+
 
 " Native highlighting ==========================================================
 

--- a/colors/gotham256.vim
+++ b/colors/gotham256.vim
@@ -87,6 +87,24 @@ let s:colors.blue    = { 'gui': '#195466', 'cterm': 24  }
 let s:colors.cyan    = { 'gui': '#33859E', 'cterm': 44  }
 let s:colors.green   = { 'gui': '#2aa889', 'cterm': 78  }
 
+" Neovim :terminal colors.
+let g:terminal_color_0  = get(s:colors.base0, 'gui')
+let g:terminal_color_8  = get(s:colors.base1, 'gui')
+let g:terminal_color_1  = get(s:colors.red, 'gui')
+let g:terminal_color_9  = get(s:colors.orange, 'gui')
+let g:terminal_color_2  = get(s:colors.green, 'gui')
+let g:terminal_color_10 = get(s:colors.base2, 'gui')
+let g:terminal_color_3  = get(s:colors.yellow, 'gui')
+let g:terminal_color_11 = get(s:colors.base4, 'gui')
+let g:terminal_color_4  = get(s:colors.blue, 'gui')
+let g:terminal_color_12 = get(s:colors.base3, 'gui')
+let g:terminal_color_5  = get(s:colors.violet, 'gui')
+let g:terminal_color_13 = get(s:colors.magenta, 'gui')
+let g:terminal_color_6  = get(s:colors.cyan, 'gui')
+let g:terminal_color_14 = get(s:colors.base5, 'gui')
+let g:terminal_color_7  = get(s:colors.base6, 'gui')
+let g:terminal_color_15 = get(s:colors.base7, 'gui')
+
 
 " Native highlighting ==========================================================
 


### PR DESCRIPTION
Use the Gotham color palette instead of the xterm color palette for Neovim's built-in terminal emulator.