### PR TITLE
Don't use the "bright" colors in :terminal

### DIFF
--- a/colors/gotham.vim
+++ b/colors/gotham.vim
@@ -89,21 +89,21 @@ let s:colors.green   = { 'gui': '#2aa889', 'cterm': 2  }
 
 " Neovim :terminal colors.
 let g:terminal_color_0  = get(s:colors.base0, 'gui')
-let g:terminal_color_8  = get(s:colors.base1, 'gui')
+let g:terminal_color_8  = g:terminal_color_0
 let g:terminal_color_1  = get(s:colors.red, 'gui')
-let g:terminal_color_9  = get(s:colors.orange, 'gui')
+let g:terminal_color_9  = g:terminal_color_1
 let g:terminal_color_2  = get(s:colors.green, 'gui')
-let g:terminal_color_10 = get(s:colors.base2, 'gui')
+let g:terminal_color_10 = g:terminal_color_2
 let g:terminal_color_3  = get(s:colors.yellow, 'gui')
-let g:terminal_color_11 = get(s:colors.base4, 'gui')
+let g:terminal_color_11 = g:terminal_color_3
 let g:terminal_color_4  = get(s:colors.blue, 'gui')
-let g:terminal_color_12 = get(s:colors.base3, 'gui')
+let g:terminal_color_12 = g:terminal_color_4
 let g:terminal_color_5  = get(s:colors.violet, 'gui')
-let g:terminal_color_13 = get(s:colors.magenta, 'gui')
+let g:terminal_color_13 = g:terminal_color_5
 let g:terminal_color_6  = get(s:colors.cyan, 'gui')
-let g:terminal_color_14 = get(s:colors.base5, 'gui')
+let g:terminal_color_14 = g:terminal_color_6
 let g:terminal_color_7  = get(s:colors.base6, 'gui')
-let g:terminal_color_15 = get(s:colors.base7, 'gui')
+let g:terminal_color_15 = g:terminal_color_7
 
 
 " Native highlighting ==========================================================

--- a/colors/gotham256.vim
+++ b/colors/gotham256.vim
@@ -89,21 +89,21 @@ let s:colors.green   = { 'gui': '#2aa889', 'cterm': 78  }
 
 " Neovim :terminal colors.
 let g:terminal_color_0  = get(s:colors.base0, 'gui')
-let g:terminal_color_8  = get(s:colors.base1, 'gui')
+let g:terminal_color_8  = g:terminal_color_0
 let g:terminal_color_1  = get(s:colors.red, 'gui')
-let g:terminal_color_9  = get(s:colors.orange, 'gui')
+let g:terminal_color_9  = g:terminal_color_1
 let g:terminal_color_2  = get(s:colors.green, 'gui')
-let g:terminal_color_10 = get(s:colors.base2, 'gui')
+let g:terminal_color_10 = g:terminal_color_2
 let g:terminal_color_3  = get(s:colors.yellow, 'gui')
-let g:terminal_color_11 = get(s:colors.base4, 'gui')
+let g:terminal_color_11 = g:terminal_color_3
 let g:terminal_color_4  = get(s:colors.blue, 'gui')
-let g:terminal_color_12 = get(s:colors.base3, 'gui')
+let g:terminal_color_12 = g:terminal_color_4
 let g:terminal_color_5  = get(s:colors.violet, 'gui')
-let g:terminal_color_13 = get(s:colors.magenta, 'gui')
+let g:terminal_color_13 = g:terminal_color_5
 let g:terminal_color_6  = get(s:colors.cyan, 'gui')
-let g:terminal_color_14 = get(s:colors.base5, 'gui')
+let g:terminal_color_14 = g:terminal_color_6
 let g:terminal_color_7  = get(s:colors.base6, 'gui')
-let g:terminal_color_15 = get(s:colors.base7, 'gui')
+let g:terminal_color_15 = g:terminal_color_7
 
 
 " Native highlighting ==========================================================


### PR DESCRIPTION
Gotham, like many other color schemes (such as base16 and solarized) that try to support 16-color terminals , "abuses" the bright terminal colors (terminal colors 8-15) to function. For example, it expects color 10 (`Bright Green`) to be a color (`#091f2e`) that is neither very green nor bright. This causes some terminal applications to look weird since they expect the bright colors to be bright :stuck_out_tongue:. With this patch neovim's `:terminal` ignores the colors 8-15 from gotham's palette and re-uses colors 0-7 instead.