### PR TITLE
added Function coloring

### DIFF
--- a/colors/gotham.vim
+++ b/colors/gotham.vim
@@ -135,6 +135,7 @@ call s:Col('Number', 'orange')
 call s:Col('Statement', 'base5')
 call s:Col('Special', 'orange')
 call s:Col('Identifier', 'base5')
+call s:Col('Function', 'violet')
 
 " Constants, Ruby symbols.
 call s:Col('Constant', 'magenta')
@@ -222,7 +223,6 @@ call s:Col('DiffSubname', 'base4')
 
 " Directories (e.g. netrw).
 call s:Col('Directory', 'cyan')
-
 
 " Programming languages and filetypes ==========================================
 

--- a/colors/gotham256.vim
+++ b/colors/gotham256.vim
@@ -135,6 +135,7 @@ call s:Col('Number', 'orange')
 call s:Col('Statement', 'base5')
 call s:Col('Special', 'orange')
 call s:Col('Identifier', 'base5')
+call s:Col('Function', 'violet')
 
 " Constants, Ruby symbols.
 call s:Col('Constant', 'magenta')


### PR DESCRIPTION
I used violet color, as per suggestion to use existing colors, but personally, I don't like the way it looks in result. I'd prefer a more contrasting color, as in my example. Something like:

    let s:colors.sea   = { 'gui': '#4d618e', 'cterm': 4  }
    ...
    " Function.
    call s:Col('Function', 'sea')