### PR TITLE
Make buffer name color on airline lighter

### DIFF
--- a/autoload/airline/themes/gotham.vim
+++ b/autoload/airline/themes/gotham.vim
@@ -42,7 +42,7 @@ endfunction
 " Normal mode =================================================================
 
 " Colors.
-let s:N1 = s:Array('base2', 'blue')
+let s:N1 = s:Array('base6', 'blue')
 let s:N2 = s:Array('base5', 'base2')
 let s:N3 = s:Array('blue', 'base1')
 

--- a/autoload/airline/themes/gotham256.vim
+++ b/autoload/airline/themes/gotham256.vim
@@ -42,7 +42,7 @@ endfunction
 " Normal mode =================================================================
 
 " Colors.
-let s:N1 = s:Array('base2', 'blue')
+let s:N1 = s:Array('base6', 'blue')
 let s:N2 = s:Array('base5', 'base2')
 let s:N3 = s:Array('blue', 'base1')
 


### PR DESCRIPTION
As shown in  #38 buffer name is hard to read, this pr fixes it by using a lighter color for the buffer name.

![screenshot_2017-06-23_11-30-52](https://user-images.githubusercontent.com/370322/27495699-e5110336-5807-11e7-82a7-3869fa3feca5.png)
