### PR TITLE
fix undefined method error when loading Airline theme gotham256

### DIFF
--- a/autoload/airline/themes/gotham256.vim
+++ b/autoload/airline/themes/gotham256.vim
@@ -90,11 +90,11 @@ let s:R1 = s:Array('base2', 'orange')
 let s:R2 = s:Array('base6', 'base3')
 let s:R3 = s:Array('blue', 'base1')
 
-let g:airline#themes#gotham#palette.replace =
+let g:airline#themes#gotham256#palette.replace =
       \ airline#themes#generate_color_map(s:R1, s:R2, s:R3)
 
 " Overrides for when the buffer is modified in normal mode.
-let g:airline#themes#gotham#palette.replace_modified = {
+let g:airline#themes#gotham256#palette.replace_modified = {
       \ 'airline_c': s:Array('magenta', 'base1', '')
       \ }
 


### PR DESCRIPTION
https://github.com/whatyouhide/vim-gotham/issues/49

i think this may fix the issue described in issue 49, which I could eventually reproduce by executing `:AirlineTheme gotham256` from vim command line.. Oddly enough, the first time I run the command, i get `The specified theme could not be found` ... but if I run the command again, I get the same errors that were mentioned by @acarl005
Since I couldn't get the error using the `gotham` theme for Airline, I started at the source code for `gotham256`, and noticed that the palette defined for replace mode,
 `g:airline#themes#gotham#palette.replace` did not have the `256` in the name... perhaps this is causing airline some confusion?

anyways, i have not seen the error since making the change. take a look and let me know if you think it is relevant.
thanks

![image](https://user-images.githubusercontent.com/1677274/46911185-0684bc00-cf22-11e8-88f5-e50432fd1710.png)
