### PR TITLE
add check to 256 color about vim

### DIFF
--- a/colors/gotham256.vim
+++ b/colors/gotham256.vim
@@ -18,6 +18,9 @@ if exists('syntax_on') | syntax reset | endif
 set background=dark
 let g:colors_name = 'gotham256'
 
+if !(has('termguicolors') && &termguicolors) && !has('gui_running') && &t_Co != 256
+  finish
+endif
 
 " Helper functions =============================================================
 


### PR DESCRIPTION
Hi!
I added a patch about check to 256 color about Vim.
This patch use a lot of famous colorscheme.

Please check this Pull Request!

## like this

>https://github.com/morhetz/gruvbox/blob/cb4e7a5643f7d2dd40e694bcbd28c4b89b185e86/colors/gruvbox.vim#L21-L23

>https://github.com/dracula/vim/blob/c8c0a9325407c487fd702eca39d987d67123c98b/colors/dracula.vim#L28-L30