### PR TITLE
[add] ci's badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 > It's the colorscheme we set that defines us. *(Batman)*
 
+[![main](https://github.com/whatyouhide/vim-gotham/workflows/main/badge.svg?branch=master)](https://github.com/whatyouhide/vim-gotham/actions?query=workflow%3Amain)
+
 Gotham is a **very dark** vim colorscheme. It works on GUI vim (MacVim or gVim)
 and on terminal vim. For terminal vim, there's support for a lot of terminal
 emulators in the [gotham-contrib][gotham-contrib] repository.


### PR DESCRIPTION
It is a related issue #55 
I added ci's badge in README like below.
Could you check this Pull Request?

<img width="923" alt="スクリーンショット 2020-02-25 0 48 32" src="https://user-images.githubusercontent.com/36619465/75167447-b69a4400-5768-11ea-9699-a1a81d79c8ec.png">


