### PR TITLE
[update] airline's terminal section color

### DIFF
--- a/autoload/airline/themes/gotham.vim
+++ b/autoload/airline/themes/gotham.vim
@@ -145,6 +145,11 @@ let g:airline#themes#gotham#palette.accents = {
       \ }
 
 
+" Terminal =====================================================================
+
+let g:airline#themes#gotham#palette.terminal =
+      \ airline#themes#generate_color_map(s:I1, s:I2, s:I3)
+
 
 " CtrlP =======================================================================
 

--- a/autoload/airline/themes/gotham256.vim
+++ b/autoload/airline/themes/gotham256.vim
@@ -144,6 +144,10 @@ let g:airline#themes#gotham256#palette.accents = {
       \ 'red': [s:c.red.gui, '', s:c.red.cterm, '']
       \ }
 
+" Terminal =====================================================================
+
+let g:airline#themes#gotham256#palette.terminal =
+      \ airline#themes#generate_color_map(s:I1, s:I2, s:I3)
 
 
 " CtrlP =======================================================================


### PR DESCRIPTION
Hello, @whatyouhide 

I've updated the color scheme in the terminal section of the vim-airline.
This is expected to improve the user interface.
This uses the same green color scheme as the insert mode color scheme.

## screenshot

### gotham

![gotham](https://user-images.githubusercontent.com/36619465/85768308-da3fbc00-b753-11ea-8fe8-f1f9a8200173.gif)

### gotham256


![gotham256](https://user-images.githubusercontent.com/36619465/85768317-dc097f80-b753-11ea-8112-3e5196d612fc.gif)
