### PR TITLE
Fixed Missing Colors due to Neovim Update

### DIFF
--- a/colors/gotham.vim
+++ b/colors/gotham.vim
@@ -135,6 +135,12 @@ call s:Col('Number', 'orange')
 call s:Col('Statement', 'base5')
 call s:Col('Special', 'orange')
 call s:Col('Identifier', 'base5')
+call s:Col('Operator', 'base5')
+call s:Col('Delimiter', 'base6')
+call s:Col('Removed', 'red')
+call s:Col('Function', 'magenta')
+call s:Col('Changed', 'cyan')
+call s:Col('@variable', 'base6')
 
 " Constants, Ruby symbols.
 call s:Col('Constant', 'magenta')

--- a/colors/gotham256.vim
+++ b/colors/gotham256.vim
@@ -138,6 +138,12 @@ call s:Col('Number', 'orange')
 call s:Col('Statement', 'base5')
 call s:Col('Special', 'orange')
 call s:Col('Identifier', 'base5')
+call s:Col('Operator', 'base5')
+call s:Col('Delimiter', 'base6')
+call s:Col('Removed', 'red')
+call s:Col('Function', 'magenta')
+call s:Col('Changed', 'cyan')
+call s:Col('@variable', 'base6')
 
 " Constants, Ruby symbols.
 call s:Col('Constant', 'magenta')


### PR DESCRIPTION
Added the following highlight groups in gotham.vim and gotham256.vim in order to fix the missing colors:

```
call s:Col('Operator', 'base5')
call s:Col('Delimiter', 'base6')
call s:Col('Removed', 'red')
call s:Col('Function', 'magenta')
call s:Col('Changed', 'cyan')
call s:Col('@variable', 'base6')

```
